### PR TITLE
Makefile: on getting too many CapDL specs, print debug info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,5 +48,5 @@ ${BUILD_DIR}/src/capdl_spec.c: ${CAPDL_SPEC}
 	@echo " [GEN] $(notdir $@)"
 	${Q}mkdir -p "$(dir $@)"
 	${Q}$(if $^,,echo "No CapDL spec provided" >&2 ; exit 1)
-	${Q}$(if $(filter 1,$(words $^)),,echo "Multiple CapDL specs provided" >&2 ; exit 1)
+	${Q}$(if $(filter 1,$(words $^)),,echo "Error: multiple CapDL specs provided: $^" >&2 ; exit 1)
 	${Q}parse-capDL --code "$@" "$^"


### PR DESCRIPTION
I mistakenly had two applications enabled in my config and this was causing the capDL loader build process to fail. Now the error message provides a bit more guidance on what went wrong.
